### PR TITLE
Fix: Order changed of routes in user-router.

### DIFF
--- a/Client/src/contexts/UserContext.tsx
+++ b/Client/src/contexts/UserContext.tsx
@@ -45,7 +45,6 @@ export const UserProvider = ({ children }: Props) => {
       const userResponse = await response.json();
       setUser(userResponse);
     };
-
     fetchUser();
   }, []);
 

--- a/Server/src/resources/products/product-controller.ts
+++ b/Server/src/resources/products/product-controller.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
-import { ProductModel } from "./product-model";
 import mongoose from "mongoose";
+import { ProductModel } from "./product-model";
 
 export async function registerProduct(req: Request, res: Response) {
   try {
@@ -16,7 +16,6 @@ export async function registerProduct(req: Request, res: Response) {
 export async function getAllProducts(req: Request, res: Response) {
   const products = await ProductModel.find({});
   res.status(200).json(products);
-  return console.log("Get All Products");
 }
 
 export async function getAllProductsFromCategory(req: Request, res: Response) {

--- a/Server/src/resources/users/user-controller.ts
+++ b/Server/src/resources/users/user-controller.ts
@@ -102,10 +102,7 @@ export async function loginUser(req: Request, res: Response) {
     return;
   }
 
-  req.session!.username = user.username;
-  req.session!.email = user.email;
   req.session!._id = user._id;
-  req.session!.isAdmin = user.isAdmin;
 
   res.status(200).json({
     _id: user!._id,
@@ -120,12 +117,13 @@ export async function logoutUser(req: Request, res: Response) {
 }
 
 export async function checkUserInfo(req: Request, res: Response) {
-  const userData = {
-    username: req.session?.username,
-    email: req.session?.email,
-    password: req.session?.password,
-    _id: req.session?._id,
-  };
-
-  res.status(200).json(userData);
+  const user = await UserModel.findOne({ _id: req.session?._id });
+  user
+    ? res.status(200).json({
+        username: user.username,
+        email: user.email,
+        isAdmin: user.isAdmin,
+        _id: req.session?._id,
+      })
+    : res.status(404).json("User not found");
 }

--- a/Server/src/resources/users/user-router.ts
+++ b/Server/src/resources/users/user-router.ts
@@ -15,8 +15,8 @@ export const userRouter = express
   .Router()
   .post("/api/users/register", registerUser)
   .get("/api/users", auth, authAdmin, getAllUsers)
-  .put("/api/users/:id", auth, authAdmin, changeRole)
-  .get("/api/users/:id", getOneUser)
   .post("/api/users/login", loginUser)
   .post("/api/users/logout", auth, logoutUser)
-  .get("/api/users/checkUserInfo", checkUserInfo);
+  .get("/api/users/checkUserInfo", checkUserInfo)
+  .put("/api/users/:id", auth, authAdmin, changeRole)
+  .get("/api/users/:id", getOneUser);


### PR DESCRIPTION
Felet uppstod för att routerna med /:id parametern låg halvvägs upp routes listan. Därför tolkades 'checkUserInfo' i '/api/users/checkUserInfo' som ett felaktigt id.

- Ordning har ändrat på routerner i user-router
- Endast användareID:et sparas i kakan. Annat data hämtas från databasen och skickas som svar.